### PR TITLE
Avoid global variable

### DIFF
--- a/lcpp.lua
+++ b/lcpp.lua
@@ -283,6 +283,7 @@ end
 local function findn(input, what)
 	local count = 0
 	local offset = 0
+	local _
 	while true do 
 			_, offset = string.find(input, what, offset+1, true)
 			if not offset then return count end


### PR DESCRIPTION
The global ' _ ' used here is not necessary and generates warnings when using e.g. the package https://github.com/deepmind/strict to check for unintended globals.